### PR TITLE
perf(routing): 라우팅 레이턴시 개선을 위한 레이아웃 구조 변경

### DIFF
--- a/app/(main)/chat/[questionId]/_components/Layout/ChatPageShell.tsx
+++ b/app/(main)/chat/[questionId]/_components/Layout/ChatPageShell.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { Header } from '@/components/common/Header';
 
 interface ChatPageShellProps {
   chatArea: ReactNode;
@@ -8,10 +7,7 @@ interface ChatPageShellProps {
 
 export function ChatPageShell({ chatArea, sidePanel }: ChatPageShellProps) {
   return (
-    <div className="h-screen bg-white flex flex-col overflow-hidden">
-      <Header />
-
-      <main className="flex-1 flex overflow-hidden px-7.5 py-7.5 gap-7.5">
+    <main className="flex-1 flex overflow-hidden px-7.5 py-7.5 gap-7.5">
         {/* 왼쪽: 채팅 영역 */}
         <div className="flex-1 flex flex-col min-w-0 gap-7.5 overflow-hidden">
           {chatArea}
@@ -21,7 +17,6 @@ export function ChatPageShell({ chatArea, sidePanel }: ChatPageShellProps) {
         <aside className="w-103.5 bg-gray-20 border border-gray-70 rounded-7.5 flex flex-col shrink-0 overflow-hidden">
           {sidePanel}
         </aside>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/app/(main)/chat/[questionId]/loading.tsx
+++ b/app/(main)/chat/[questionId]/loading.tsx
@@ -3,7 +3,7 @@ import { ChatAreaSkeleton, ExperienceCardsSkeleton } from "./_components";
 export default function ChatPageLoading() {
   return (
     <main className="flex-1 flex overflow-hidden px-7.5 py-7.5 gap-7.5">
-      {/* 왼쪽: 채팅 영역 */}
+      {/* 의도적으로 비움 - 구조만 유지 */}
     </main>
   );
 }

--- a/app/(main)/chat/[questionId]/loading.tsx
+++ b/app/(main)/chat/[questionId]/loading.tsx
@@ -1,0 +1,9 @@
+import { ChatAreaSkeleton, ExperienceCardsSkeleton } from "./_components";
+
+export default function ChatPageLoading() {
+  return (
+    <main className="flex-1 flex overflow-hidden px-7.5 py-7.5 gap-7.5">
+      {/* 왼쪽: 채팅 영역 */}
+    </main>
+  );
+}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,0 +1,14 @@
+import { Header } from '@/components/common/Header';
+
+export default function MainLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="h-screen bg-white flex flex-col overflow-hidden">
+      <Header />
+      {children}
+    </div>
+  );
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
-import { HomeClient } from "./_components/HomeClient";
-import { ProjectListServer } from "./_components/ProjectListServer";
-import { ProjectListSkeleton } from "./_components/ProjectListSkeleton";
+import { HomeClient } from "../_components/HomeClient";
+import { ProjectListServer } from "../_components/ProjectListServer";
+import { ProjectListSkeleton } from "../_components/ProjectListSkeleton";
 
 export default function Home() {
   return (

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { Header } from "@/components/common/Header";
 import {
   Carousel,
   CarouselContent,
@@ -84,10 +83,7 @@ export function HomeClient({ projectListSlot }: HomeClientProps) {
   };
 
   return (
-    <div className="min-h-screen bg-white">
-      <Header />
-
-      <main className="max-w-276 mx-auto pt-10 pb-25">
+    <main className="max-w-276 mx-auto pt-10 pb-25 flex-1 overflow-y-auto">
         <h1 className="text-headline-1 text-gray-400 mb-16">
           어떤 자기소개서를 작성하시겠어요?
         </h1>
@@ -135,7 +131,6 @@ export function HomeClient({ projectListSlot }: HomeClientProps) {
 
         {/* 디자인 토큰 테스트 섹션 */}
         <DesignTokensTest />
-      </main>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

현재 프로덕션에서 라우팅이 지연되는 이슈가 있습니다... 이 부분을 개선하기 위해 레이아웃 구조를 변경하고 loading.tsx를 추가했습니다.
(클릭하고 한 2초 뒤에 라우팅 됨)

https://github.com/user-attachments/assets/a9208460-bfcd-4c50-a61d-c999282cb31d


## Tasks

- [x] `(main)` route group 추가 및 공통 레이아웃 분리
- [x] 채팅 페이지 `loading.tsx` 추가로 라우팅 시 즉시 전환 지원
- [x] Header를 공통 레이아웃으로 이동하여 라우팅 시 리렌더링 방지

## To Reviewer

### 변경된 라우팅 구조
```
  app/                                                                                                                                                                                  
  ├── layout.tsx (root)                                                                                                                                                                 
  └── (main)/                                                                                                                                                                           
      ├── layout.tsx    ← Header 공유                                                                                                                                                   
      ├── page.tsx      ← 홈                                                                                                                                                            
      └── chat/[questionId]/                                                                                                                                                            
          ├── page.tsx                                                                                                                                                                  
          └── loading.tsx ← 즉시 전환용 
```


### 개선 포인트

1. **`loading.tsx` 추가**: 라우팅 시 데이터 로딩을 기다리지 않고 즉시 화면 전환
2. **공통 Layout 공유**: 홈과 채팅이 같은 layout을 공유하여 Header 리렌더링 방지 (Partial Rendering)

### loading.tsx를 비워둔 이유

`loading.tsx` 내부에 스켈레톤 UI를 넣지 않고 레이아웃 구조만 유지한 이유:

1. **이중 스켈레톤 방지**: 채팅 페이지 내부에 이미 Suspense fallback으로 스켈레톤이 정의되어 있음. loading.tsx에도 스켈레톤을 넣으면 `스켈레톤 → 스켈레톤 → 콘텐츠` 형태의 어색한 전환이 발생
2. **Suspense boundary 역할만 수행**: 빈 껍데기여도 `loading.tsx` 파일이 존재하면 Next.js가 Suspense boundary를 생성하여 라우팅 즉시 전환 효과는 유지됨
3. **Header 유지**: `(main)/layout.tsx`에서 Header를 공유하므로, loading.tsx가 비어있어도 Header는 계속 보임

### 프로덕션 테스트 필요

로컬 환경에서는 네트워크 지연이 거의 없어 체감 차이가 미미합니다. 프로덕션 배포 후 실제 네트워크 환경에서 다음 항목을 테스트할 예정입니다!
- [ ] 홈 → 채팅 라우팅 시 빈 화면이 눈에 띄게 보이는지 확인
- [ ] 느린 네트워크(Fast 3G) 환경에서 UX 확인
- [ ] 필요 시 로딩 오버레이(로고 + 스피너) 추가 검토