### PR TITLE
Feat(chat): 채팅 페이지에 문항 관리 및 경험 추가 모달 구현

### DIFF
--- a/app/(main)/chat/[projectId]/_components/Experience/ExperienceListShell.tsx
+++ b/app/(main)/chat/[projectId]/_components/Experience/ExperienceListShell.tsx
@@ -4,9 +4,10 @@ import { ReactNode } from 'react';
 
 interface ExperienceListShellProps {
   children: ReactNode;
+  onAddClick: () => void;
 }
 
-export function ExperienceListShell({ children }: ExperienceListShellProps) {
+export function ExperienceListShell({ children, onAddClick }: ExperienceListShellProps) {
   return (
     <div className="flex-1 flex flex-col gap-5 pt-5 pb-8 overflow-hidden">
       <p className="text-body-5-5 text-gray-400 opacity-60 px-7">
@@ -14,8 +15,11 @@ export function ExperienceListShell({ children }: ExperienceListShellProps) {
       </p>
 
       <div className="flex-1 flex flex-col gap-7 overflow-y-auto px-7">
-        <button className="w-full h-15 flex items-center justify-center bg-primary-50 rounded-3.5 hover:bg-primary-70 transition-colors shrink-0 cursor-pointer">
-          <span className="text-body-3-2 text-gray-300">+추가하기</span>
+        <button
+          onClick={onAddClick}
+          className="group w-full h-15 flex items-center justify-center bg-primary-50 rounded-3.5 hover:bg-primary-70 transition-colors shrink-0 cursor-pointer"
+        >
+          <span className="text-body-3-2 text-gray-300 group-hover:text-gray-400 transition-colors">+추가하기</span>
         </button>
 
         {children}

--- a/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
+++ b/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
@@ -1,19 +1,26 @@
 "use client";
 
+import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useProjectContext } from "../../_context";
 import { ChatProjectSummary } from "./ChatProjectSummary";
 import { ChatQuestionTabs } from "./ChatQuestionTabs";
+import { ManageQuestionsModal } from "../ManageQuestionsModal";
 
 export function ChatHeader() {
   const router = useRouter();
   const { questionId } = useParams<{ projectId: string; questionId: string }>();
   const { projectId, company, jobPosition, questions } = useProjectContext();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const currentQuestion = questions.find((q) => q.id === questionId);
   const currentQuestionText = currentQuestion?.question ?? "";
 
   const handleQuestionChange = (newQuestionId: string) => {
+    router.push(`/chat/${projectId}/${newQuestionId}`);
+  };
+
+  const handleQuestionAdded = (newQuestionId: string) => {
     router.push(`/chat/${projectId}/${newQuestionId}`);
   };
 
@@ -25,9 +32,18 @@ export function ChatHeader() {
           questions={questions}
           activeQuestionId={questionId}
           onQuestionChange={handleQuestionChange}
+          onAddClick={() => setIsModalOpen(true)}
         />
       </div>
       <h1 className="text-title-3 text-gray-400">{currentQuestionText}</h1>
+
+      <ManageQuestionsModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        projectId={projectId}
+        questions={questions}
+        onQuestionAdded={handleQuestionAdded}
+      />
     </>
   );
 }

--- a/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
+++ b/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
@@ -23,10 +23,6 @@ export function ChatHeader() {
     router.push(`/chat/${projectId}/${newQuestionId}`);
   };
 
-  const handleQuestionAdded = (newQuestionId: string) => {
-    router.push(`/chat/${projectId}/${newQuestionId}`);
-  };
-
   return (
     <>
       <div className="flex flex-col gap-5 shrink-0">
@@ -45,7 +41,8 @@ export function ChatHeader() {
         onOpenChange={setIsModalOpen}
         projectId={projectId}
         questions={questions}
-        onQuestionAdded={handleQuestionAdded}
+        currentQuestionId={questionId}
+        onQuestionChange={handleQuestionChange}
       />
     </>
   );

--- a/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
+++ b/app/(main)/chat/[projectId]/_components/Layout/ChatHeader.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useProjectContext } from "../../_context";
+import { useChatStore } from "../../_store/useChatStore";
 import { ChatProjectSummary } from "./ChatProjectSummary";
 import { ChatQuestionTabs } from "./ChatQuestionTabs";
 import { ManageQuestionsModal } from "../ManageQuestionsModal";
@@ -12,11 +13,13 @@ export function ChatHeader() {
   const { questionId } = useParams<{ projectId: string; questionId: string }>();
   const { projectId, company, jobPosition, questions } = useProjectContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const clearSelection = useChatStore((s) => s.clearSelection);
 
   const currentQuestion = questions.find((q) => q.id === questionId);
   const currentQuestionText = currentQuestion?.question ?? "";
 
   const handleQuestionChange = (newQuestionId: string) => {
+    clearSelection();
     router.push(`/chat/${projectId}/${newQuestionId}`);
   };
 

--- a/app/(main)/chat/[projectId]/_components/Layout/ChatQuestionTabs.tsx
+++ b/app/(main)/chat/[projectId]/_components/Layout/ChatQuestionTabs.tsx
@@ -11,12 +11,14 @@ interface ChatQuestionTabsProps {
   questions: QuestionTabItem[];
   activeQuestionId: string;
   onQuestionChange: (questionId: string) => void;
+  onAddClick: () => void;
 }
 
 export function ChatQuestionTabs({
   questions,
   activeQuestionId,
   onQuestionChange,
+  onAddClick,
 }: ChatQuestionTabsProps) {
   return (
     <div className="flex items-center gap-8">
@@ -39,7 +41,10 @@ export function ChatQuestionTabs({
           </button>
         );
       })}
-      <button className="flex items-center justify-center text-gray-300 hover:text-gray-400 transition-colors shrink-0 cursor-pointer">
+      <button
+        onClick={onAddClick}
+        className="flex items-center justify-center text-gray-300 hover:text-gray-400 transition-colors shrink-0 cursor-pointer"
+      >
         <Plus className="w-4.5 h-4.5" strokeWidth={2} />
       </button>
     </div>

--- a/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
+++ b/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { QuestionFieldItem } from "@/app/_components/QuestionFieldItem";
+import { createQuestion, updateQuestion } from "@/app/_actions/projects";
+import type { QuestionListItem } from "@/types/api";
+
+interface QuestionField {
+  id: string | null;
+  question: string;
+  max_length: number | null;
+  isNew: boolean;
+  isDirty: boolean;
+}
+
+interface ManageQuestionsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  questions: QuestionListItem[];
+  onQuestionAdded: (newQuestionId: string) => void;
+}
+
+export function ManageQuestionsModal({
+  open,
+  onOpenChange,
+  projectId,
+  questions,
+  onQuestionAdded,
+}: ManageQuestionsModalProps) {
+  const [isPending, startTransition] = useTransition();
+  const [fields, setFields] = useState<QuestionField[]>(() =>
+    questions.map((q) => ({
+      id: q.id,
+      question: q.question,
+      max_length: q.max_length,
+      isNew: false,
+      isDirty: false,
+    })),
+  );
+
+  const resetFields = () => {
+    setFields(
+      questions.map((q) => ({
+        id: q.id,
+        question: q.question,
+        max_length: q.max_length,
+        isNew: false,
+        isDirty: false,
+      })),
+    );
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+    resetFields();
+  };
+
+  const handleAddField = () => {
+    setFields((prev) => [
+      ...prev,
+      { id: null, question: "", max_length: null, isNew: true, isDirty: true },
+    ]);
+  };
+
+  const handleRemoveField = (index: number) => {
+    setFields((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleQuestionChange = (index: number, value: string) => {
+    setFields((prev) =>
+      prev.map((f, i) =>
+        i === index ? { ...f, question: value, isDirty: true } : f,
+      ),
+    );
+  };
+
+  const handleMaxLengthChange = (index: number, value: number | null) => {
+    setFields((prev) =>
+      prev.map((f, i) =>
+        i === index ? { ...f, max_length: value, isDirty: true } : f,
+      ),
+    );
+  };
+
+  const handleSave = () => {
+    startTransition(async () => {
+      try {
+        const dirtyFields = fields.filter((f) => f.isDirty);
+
+        for (const field of dirtyFields) {
+          if (field.isNew) {
+            if (!field.question.trim()) continue;
+
+            const result = await createQuestion(projectId, {
+              question: field.question,
+              max_length: field.max_length ?? null,
+            });
+
+            onQuestionAdded(result.id);
+            handleClose();
+            return;
+          } else if (field.id) {
+            await updateQuestion(projectId, field.id, {
+              question: field.question,
+              max_length: field.max_length ?? null,
+            });
+          }
+        }
+
+        handleClose();
+      } catch {
+        alert("문항 저장 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+      }
+    });
+  };
+
+  const hasDirtyFields = fields.some((f) => f.isDirty);
+  const hasNewFields = fields.some((f) => f.isNew);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex max-h-[90vh] flex-col overflow-hidden rounded-2xl border-0 p-0 shadow-chat sm:max-w-2xl"
+        onPointerDownOutside={(e) => {
+          e.preventDefault();
+          handleClose();
+        }}
+        onEscapeKeyDown={handleClose}
+      >
+        <div className="shrink-0 px-8 pt-6 pb-5">
+          <DialogHeader>
+            <DialogTitle className="text-title-2-2 text-gray-400">
+              문항 관리
+            </DialogTitle>
+            <DialogDescription className="text-body-7-2 text-primary-400">
+              문항을 수정하거나 새 문항을 추가하세요.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-8 pb-6">
+          <div className="flex flex-col gap-5">
+            {fields.map((field, index) => (
+              <QuestionFieldItem
+                key={field.id ?? `new-${index}`}
+                index={index}
+                questionValue={field.question}
+                maxLengthValue={field.max_length}
+                onQuestionChange={(value) => handleQuestionChange(index, value)}
+                onMaxLengthChange={(value) =>
+                  handleMaxLengthChange(index, value)
+                }
+                onRemove={() => handleRemoveField(index)}
+                showRemoveButton={fields.length > 1}
+              />
+            ))}
+
+            <button
+              type="button"
+              onClick={handleAddField}
+              className="group w-full h-11 flex items-center justify-center bg-primary-50 rounded-3.5 hover:bg-primary-70 transition-colors cursor-pointer"
+            >
+              <span className="text-body-5-2 text-gray-300 group-hover:text-gray-400 transition-colors">
+                + 추가하기
+              </span>
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 px-8 py-5 border-t border-gray-70">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleClose}
+            disabled={isPending}
+            className="h-11 px-5 text-body-5-2"
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isPending || !hasDirtyFields}
+            className="h-11 px-5 text-body-5-2 text-white"
+          >
+            {isPending ? "저장 중..." : hasNewFields ? "문항 추가" : "저장"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
+++ b/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import {
   Dialog,
   DialogContent,
@@ -41,6 +42,7 @@ export function ManageQuestionsModal({
   currentQuestionId,
   onQuestionChange,
 }: ManageQuestionsModalProps) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [fields, setFields] = useState<QuestionField[]>([]);
 
@@ -90,24 +92,20 @@ export function ManageQuestionsModal({
 
     if (!field.id) return;
 
-    startTransition(async () => {
-      try {
-        await deleteQuestion(projectId, field.id!);
+    const remainingFields = fields.filter((_, i) => i !== index);
 
-        const remainingFields = fields.filter((_, i) => i !== index);
-        setFields(remainingFields);
-
-        if (field.id === currentQuestionId) {
-          const nextQuestion = remainingFields.find((f) => !f.isNew && f.id);
-          if (nextQuestion?.id) {
-            onQuestionChange(nextQuestion.id);
-          }
-        }
-
-        handleClose();
-      } catch {
-        alert("문항 삭제 중 오류가 발생했습니다.");
+    if (field.id === currentQuestionId) {
+      const nextQuestion = remainingFields.find((f) => !f.isNew && f.id);
+      if (nextQuestion?.id) {
+        onQuestionChange(nextQuestion.id);
       }
+    }
+
+    handleClose();
+
+    deleteQuestion(projectId, field.id).catch(() => {
+      alert("문항 삭제 중 오류가 발생했습니다. 페이지를 새로고침합니다.");
+      router.refresh();
     });
   };
 
@@ -124,41 +122,48 @@ export function ManageQuestionsModal({
   };
 
   const handleSave = () => {
-    startTransition(async () => {
-      try {
-        for (const field of fields) {
-          if (field.isNew) {
-            if (!field.question.trim()) continue;
-
-            const result = await createQuestion(projectId, {
-              question: field.question,
-              max_length: field.max_length ?? null,
-            });
-
-            onQuestionChange(result.id);
-            handleClose();
-            return;
-          } else if (field.id) {
-            const original = questions.find((q) => q.id === field.id);
-            const isChanged =
-              original &&
-              (field.question !== original.question ||
-                field.max_length !== original.max_length);
-
-            if (isChanged) {
-              await updateQuestion(projectId, field.id, {
-                question: field.question,
-                max_length: field.max_length ?? null,
-              });
-            }
-          }
-        }
-
-        handleClose();
-      } catch {
-        alert("문항 저장 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-      }
+    const newField = fields.find((f) => f.isNew && f.question.trim());
+    const changedFields = fields.filter((field) => {
+      if (field.isNew || !field.id) return false;
+      const original = questions.find((q) => q.id === field.id);
+      return (
+        original &&
+        (field.question !== original.question ||
+          field.max_length !== original.max_length)
+      );
     });
+
+    if (newField) {
+      startTransition(async () => {
+        try {
+          const result = await createQuestion(projectId, {
+            question: newField.question,
+            max_length: newField.max_length ?? null,
+          });
+          onQuestionChange(result.id);
+          handleClose();
+        } catch {
+          alert("문항 생성 중 오류가 발생했습니다.");
+        }
+      });
+      return;
+    }
+
+    if (changedFields.length > 0) {
+      handleClose();
+
+      Promise.all(
+        changedFields.map((field) =>
+          updateQuestion(projectId, field.id!, {
+            question: field.question,
+            max_length: field.max_length ?? null,
+          }),
+        ),
+      ).catch(() => {
+        alert("문항 수정 중 오류가 발생했습니다. 페이지를 새로고침합니다.");
+        router.refresh();
+      });
+    }
   };
 
   const hasChanges = (() => {

--- a/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
+++ b/app/(main)/chat/[projectId]/_components/ManageQuestionsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -10,7 +10,11 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { QuestionFieldItem } from "@/app/_components/QuestionFieldItem";
-import { createQuestion, updateQuestion } from "@/app/_actions/projects";
+import {
+  createQuestion,
+  updateQuestion,
+  deleteQuestion,
+} from "@/app/_actions/projects";
 import type { QuestionListItem } from "@/types/api";
 
 interface QuestionField {
@@ -18,7 +22,6 @@ interface QuestionField {
   question: string;
   max_length: number | null;
   isNew: boolean;
-  isDirty: boolean;
 }
 
 interface ManageQuestionsModalProps {
@@ -26,7 +29,8 @@ interface ManageQuestionsModalProps {
   onOpenChange: (open: boolean) => void;
   projectId: string;
   questions: QuestionListItem[];
-  onQuestionAdded: (newQuestionId: string) => void;
+  currentQuestionId: string;
+  onQuestionChange: (questionId: string) => void;
 }
 
 export function ManageQuestionsModal({
@@ -34,18 +38,24 @@ export function ManageQuestionsModal({
   onOpenChange,
   projectId,
   questions,
-  onQuestionAdded,
+  currentQuestionId,
+  onQuestionChange,
 }: ManageQuestionsModalProps) {
   const [isPending, startTransition] = useTransition();
-  const [fields, setFields] = useState<QuestionField[]>(() =>
-    questions.map((q) => ({
-      id: q.id,
-      question: q.question,
-      max_length: q.max_length,
-      isNew: false,
-      isDirty: false,
-    })),
-  );
+  const [fields, setFields] = useState<QuestionField[]>([]);
+
+  useEffect(() => {
+    if (open) {
+      setFields(
+        questions.map((q) => ({
+          id: q.id,
+          question: q.question,
+          max_length: q.max_length,
+          isNew: false,
+        })),
+      );
+    }
+  }, [open, questions]);
 
   const resetFields = () => {
     setFields(
@@ -54,7 +64,6 @@ export function ManageQuestionsModal({
         question: q.question,
         max_length: q.max_length,
         isNew: false,
-        isDirty: false,
       })),
     );
   };
@@ -67,36 +76,57 @@ export function ManageQuestionsModal({
   const handleAddField = () => {
     setFields((prev) => [
       ...prev,
-      { id: null, question: "", max_length: null, isNew: true, isDirty: true },
+      { id: null, question: "", max_length: null, isNew: true },
     ]);
   };
 
   const handleRemoveField = (index: number) => {
-    setFields((prev) => prev.filter((_, i) => i !== index));
+    const field = fields[index];
+
+    if (field.isNew) {
+      setFields((prev) => prev.filter((_, i) => i !== index));
+      return;
+    }
+
+    if (!field.id) return;
+
+    startTransition(async () => {
+      try {
+        await deleteQuestion(projectId, field.id!);
+
+        const remainingFields = fields.filter((_, i) => i !== index);
+        setFields(remainingFields);
+
+        if (field.id === currentQuestionId) {
+          const nextQuestion = remainingFields.find((f) => !f.isNew && f.id);
+          if (nextQuestion?.id) {
+            onQuestionChange(nextQuestion.id);
+          }
+        }
+
+        handleClose();
+      } catch {
+        alert("문항 삭제 중 오류가 발생했습니다.");
+      }
+    });
   };
 
   const handleQuestionChange = (index: number, value: string) => {
     setFields((prev) =>
-      prev.map((f, i) =>
-        i === index ? { ...f, question: value, isDirty: true } : f,
-      ),
+      prev.map((f, i) => (i === index ? { ...f, question: value } : f)),
     );
   };
 
   const handleMaxLengthChange = (index: number, value: number | null) => {
     setFields((prev) =>
-      prev.map((f, i) =>
-        i === index ? { ...f, max_length: value, isDirty: true } : f,
-      ),
+      prev.map((f, i) => (i === index ? { ...f, max_length: value } : f)),
     );
   };
 
   const handleSave = () => {
     startTransition(async () => {
       try {
-        const dirtyFields = fields.filter((f) => f.isDirty);
-
-        for (const field of dirtyFields) {
+        for (const field of fields) {
           if (field.isNew) {
             if (!field.question.trim()) continue;
 
@@ -105,14 +135,22 @@ export function ManageQuestionsModal({
               max_length: field.max_length ?? null,
             });
 
-            onQuestionAdded(result.id);
+            onQuestionChange(result.id);
             handleClose();
             return;
           } else if (field.id) {
-            await updateQuestion(projectId, field.id, {
-              question: field.question,
-              max_length: field.max_length ?? null,
-            });
+            const original = questions.find((q) => q.id === field.id);
+            const isChanged =
+              original &&
+              (field.question !== original.question ||
+                field.max_length !== original.max_length);
+
+            if (isChanged) {
+              await updateQuestion(projectId, field.id, {
+                question: field.question,
+                max_length: field.max_length ?? null,
+              });
+            }
           }
         }
 
@@ -123,8 +161,18 @@ export function ManageQuestionsModal({
     });
   };
 
-  const hasDirtyFields = fields.some((f) => f.isDirty);
-  const hasNewFields = fields.some((f) => f.isNew);
+  const hasChanges = (() => {
+    if (fields.length !== questions.length) return true;
+
+    return fields.some((field, index) => {
+      const original = questions[index];
+      if (!original) return true;
+      if (field.id !== original.id) return true;
+      if (field.question !== original.question) return true;
+      if (field.max_length !== original.max_length) return true;
+      return false;
+    });
+  })();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -160,7 +208,11 @@ export function ManageQuestionsModal({
                   handleMaxLengthChange(index, value)
                 }
                 onRemove={() => handleRemoveField(index)}
-                showRemoveButton={fields.length > 1}
+                showRemoveButton={
+                  field.isNew
+                    ? fields.length > 1
+                    : fields.filter((f) => !f.isNew).length > 1
+                }
               />
             ))}
 
@@ -189,10 +241,10 @@ export function ManageQuestionsModal({
           <Button
             type="button"
             onClick={handleSave}
-            disabled={isPending || !hasDirtyFields}
+            disabled={isPending || !hasChanges}
             className="h-11 px-5 text-body-5-2 text-white"
           >
-            {isPending ? "저장 중..." : hasNewFields ? "문항 추가" : "저장"}
+            {isPending ? "저장 중..." : "업데이트"}
           </Button>
         </div>
       </DialogContent>

--- a/app/(main)/chat/[projectId]/_components/Panel/ChatPanel.tsx
+++ b/app/(main)/chat/[projectId]/_components/Panel/ChatPanel.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { useState, ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
 import { ChatPanelTabs } from './ChatPanelTabs';
 import { ExperienceListShell } from '../Experience/ExperienceListShell';
 import { DraftPanel } from './DraftPanel';
 import { useChatStore } from '../../_store/useChatStore';
+import { NewExperienceModal } from '@/app/_components/NewExperienceModal';
 
 interface ChatPanelProps {
   maxLength?: number;
@@ -12,20 +14,34 @@ interface ChatPanelProps {
 }
 
 export function ChatPanel({ maxLength, experienceCards }: ChatPanelProps) {
+  const router = useRouter();
   const activeTab = useChatStore((s) => s.activePanelTab);
   const storeMaxLength = useChatStore((s) => s.maxLength);
+  const [isExperienceModalOpen, setIsExperienceModalOpen] = useState(false);
 
   const effectiveMaxLength = maxLength ?? storeMaxLength;
+
+  const handleExperienceCreated = () => {
+    router.refresh();
+  };
 
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       <ChatPanelTabs />
 
       {activeTab === 'EXPERIENCES' ? (
-        <ExperienceListShell>{experienceCards}</ExperienceListShell>
+        <ExperienceListShell onAddClick={() => setIsExperienceModalOpen(true)}>
+          {experienceCards}
+        </ExperienceListShell>
       ) : (
         <DraftPanel maxLength={effectiveMaxLength} />
       )}
+
+      <NewExperienceModal
+        open={isExperienceModalOpen}
+        onOpenChange={setIsExperienceModalOpen}
+        onSuccess={handleExperienceCreated}
+      />
     </div>
   );
 }

--- a/app/_actions/projects.ts
+++ b/app/_actions/projects.ts
@@ -5,7 +5,10 @@ import { apiFetch, API_ENDPOINTS } from "@/libs/api-client";
 import type {
   ProjectCreate,
   ProjectListItem,
+  Question,
+  QuestionCreate,
   QuestionListItem,
+  QuestionUpdate,
 } from "@/types/api";
 
 /**
@@ -45,4 +48,35 @@ export async function getQuestions(
   projectId: string,
 ): Promise<QuestionListItem[]> {
   return apiFetch<QuestionListItem[]>(API_ENDPOINTS.questions(projectId));
+}
+
+/**
+ * 문항 생성
+ */
+export async function createQuestion(
+  projectId: string,
+  data: QuestionCreate,
+): Promise<QuestionListItem> {
+  const result = await apiFetch<QuestionListItem>(
+    API_ENDPOINTS.questions(projectId),
+    { method: "POST", body: JSON.stringify(data) },
+  );
+  revalidatePath(`/chat/${projectId}`);
+  return result;
+}
+
+/**
+ * 문항 수정
+ */
+export async function updateQuestion(
+  projectId: string,
+  questionId: string,
+  data: QuestionUpdate,
+): Promise<Question> {
+  const result = await apiFetch<Question>(
+    API_ENDPOINTS.question(projectId, questionId),
+    { method: "PATCH", body: JSON.stringify(data) },
+  );
+  revalidatePath(`/chat/${projectId}`);
+  return result;
 }

--- a/app/_actions/projects.ts
+++ b/app/_actions/projects.ts
@@ -80,3 +80,16 @@ export async function updateQuestion(
   revalidatePath(`/chat/${projectId}`);
   return result;
 }
+
+/**
+ * 문항 삭제
+ */
+export async function deleteQuestion(
+  projectId: string,
+  questionId: string,
+): Promise<void> {
+  await apiFetch<void>(API_ENDPOINTS.question(projectId, questionId), {
+    method: "DELETE",
+  });
+  revalidatePath(`/chat/${projectId}`);
+}

--- a/app/_components/NewExperienceModal.tsx
+++ b/app/_components/NewExperienceModal.tsx
@@ -44,11 +44,13 @@ const STEP_TITLES = {
 interface NewExperienceModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
 }
 
 export function NewExperienceModal({
   open,
   onOpenChange,
+  onSuccess,
 }: NewExperienceModalProps) {
   const createExperience = useCreateExperience();
   const formRef = useRef<NewExperienceFormRef>(null);
@@ -65,6 +67,7 @@ export function NewExperienceModal({
       onSuccess: () => {
         alert("경험이 등록되었습니다.");
         handleClose();
+        onSuccess?.();
       },
       onError: () => {
         alert("등록 중 오류가 발생했습니다.");

--- a/app/_components/QuestionFieldItem.tsx
+++ b/app/_components/QuestionFieldItem.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+
+interface QuestionFieldItemProps {
+  index: number;
+  questionValue: string;
+  maxLengthValue: number | null;
+  onQuestionChange: (value: string) => void;
+  onMaxLengthChange: (value: number | null) => void;
+  onRemove?: () => void;
+  showRemoveButton?: boolean;
+}
+
+export function QuestionFieldItem({
+  index,
+  questionValue,
+  maxLengthValue,
+  onQuestionChange,
+  onMaxLengthChange,
+  onRemove,
+  showRemoveButton = true,
+}: QuestionFieldItemProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="text-body-7-2 text-gray-200 shrink-0">
+          문항 {index + 1}
+        </span>
+        {showRemoveButton && onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="text-body-9-3 text-alert hover:underline cursor-pointer"
+          >
+            삭제
+          </button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder={`${index + 1}번 문항`}
+          className="text-body-5-4"
+          value={questionValue}
+          onChange={(e) => onQuestionChange(e.target.value)}
+        />
+        <Input
+          type="number"
+          placeholder="글자수"
+          className="text-body-5-4 w-28"
+          value={maxLengthValue ?? ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            onMaxLengthChange(value ? Number(value) : null);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -176,3 +176,8 @@ export interface ExperienceCreate {
   result: string;
   category: ExperienceCategory;
 }
+
+export interface QuestionUpdate {
+  question: string;
+  max_length?: number | null;
+}


### PR DESCRIPTION
## Summary

채팅 페이지에서 문항 추가/수정 기능과 경험 추가 기능을 모달로 구현했습니다.

## Tasks

- [x] 문항 관리 모달 구현 (ManageQuestionsModal)
  - [x] 기존 문항 수정 기능
  - [x] 새 문항 추가 기능
  - [x] 문항 삭제 기능
  - [x] QuestionFieldItem 공통 컴포넌트 분리
  - [x] 서버 상태와 비교하여 변경 시 업데이트 버튼 활성화
  - [x] 낙관적 업데이트 적용 (삭제/수정 시 즉시 모달 닫힘)
- [x] 경험 추가 모달 연결
  - [x] ExperienceListShell의 +추가하기 버튼에 NewExperienceModal 연결
  - [x] 경험 등록 후 목록 갱신 (router.refresh)
- [x] UI/UX 개선
  - [x] 추가하기 버튼 hover 시 텍스트 색상 변경 효과
  - [x] 삭제 버튼 cursor-pointer 적용
- [x] 버그 수정
  - [x] 문항 탭 이동 시 경험 선택 상태 초기화 (번쩍임 현상 해결)

## To Reviewer

- `QuestionFieldItem` 컴포넌트는 현재 `ManageQuestionsModal`에서만 사용 중입니다. `NewProjectForm`에서도 동일한 UI를 사용하고 있으나, `react-hook-form`의 `useFieldArray` 방식과 호환을 위해 추후 리팩토링 예정입니다.

## Screenshot

### 문항 생성 및 삭제

https://github.com/user-attachments/assets/6e1d577c-1d28-4628-9f19-fa8fa1da74c1


### 경험 추가

https://github.com/user-attachments/assets/c0d7491f-190c-4368-b049-258d095209bb

