### PR TITLE
Feat(project): 프로젝트 생성 개선 및 채팅 페이지 자동 이동

### DIFF
--- a/app/_actions/projects.ts
+++ b/app/_actions/projects.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { apiFetch, API_ENDPOINTS } from "@/libs/api-client";
 import type {
+  Project,
   ProjectCreate,
   ProjectListItem,
   Question,
@@ -30,8 +31,8 @@ export async function getProjects(params?: {
  * 프로젝트 생성
  * 생성 성공 시 홈 페이지 캐시를 무효화하여 프로젝트 목록이 갱신됩니다.
  */
-export async function createProject(data: ProjectCreate) {
-  const result = await apiFetch(API_ENDPOINTS.projects, {
+export async function createProject(data: ProjectCreate): Promise<Project> {
+  const result = await apiFetch<Project>(API_ENDPOINTS.projects, {
     method: "POST",
     body: JSON.stringify(data),
   });

--- a/app/_components/NewProjectForm.tsx
+++ b/app/_components/NewProjectForm.tsx
@@ -15,12 +15,16 @@ const projectFormSchema = z.object({
   recruit_notice: z.string().min(1, "채용 공고를 입력해주세요"),
   company_talent: z.string().optional(),
   due_date: z.string().optional(),
-  questions: z.array(
-    z.object({
-      question: z.string(),
-      max_length: z.union([z.number(), z.nan()]).optional().nullable(),
+  questions: z
+    .array(
+      z.object({
+        question: z.string(),
+        max_length: z.union([z.number(), z.nan()]).optional().nullable(),
+      }),
+    )
+    .refine((questions) => questions.some((q) => q.question.trim()), {
+      message: "최소 1개의 문항을 입력해주세요",
     }),
-  ),
 });
 
 type ProjectFormValues = z.infer<typeof projectFormSchema>;
@@ -47,6 +51,7 @@ export function NewProjectForm({
     register,
     handleSubmit,
     control,
+    trigger,
     formState: { errors },
   } = useForm<ProjectFormValues>({
     resolver: zodResolver(projectFormSchema),
@@ -66,11 +71,6 @@ export function NewProjectForm({
   });
 
   const handleFormSubmit = (data: ProjectFormValues) => {
-    if (step === 1) {
-      goToStep(2);
-      return;
-    }
-
     const questions: QuestionCreate[] = data.questions
       .filter((q) => q.question.trim())
       .map((q) => ({
@@ -87,7 +87,7 @@ export function NewProjectForm({
         ? data.company_talent
         : undefined,
 
-      questions: questions.length > 0 ? questions : undefined,
+      questions,
     });
   };
 
@@ -221,6 +221,11 @@ export function NewProjectForm({
             >
               + 추가하기
             </Button>
+            {errors.questions?.root && (
+              <p className="text-body-9-3 text-alert">
+                {errors.questions.root.message}
+              </p>
+            )}
           </div>
         </div>
       )}
@@ -246,10 +251,9 @@ export function NewProjectForm({
           {step === 1 ? (
             <Button
               type="button"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                goToStep(2);
+              onClick={async () => {
+                const valid = await trigger(["company", "job_position", "recruit_notice"]);
+                if (valid) goToStep(2);
               }}
               className="h-11 gap-2 px-5 text-body-5-2 text-white"
             >

--- a/app/_components/NewProjectModal.tsx
+++ b/app/_components/NewProjectModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { NewProjectForm } from "./NewProjectForm";
 import { useCreateProject } from "@/app/_hooks/useCreateProject";
+import { getQuestions } from "@/app/_actions/projects";
 import { StepFormModal } from "@/components/common/StepFormModal";
 import { showToast } from "@/libs/toast";
 import type { ProjectCreate } from "@/types/api";
@@ -24,6 +26,7 @@ interface NewProjectModalProps {
 }
 
 export function NewProjectModal({ open, onOpenChange }: NewProjectModalProps) {
+  const router = useRouter();
   const createProject = useCreateProject();
   const [step, setStep] = useState<1 | 2>(1);
   const { title, description } = STEP_TITLES[step];
@@ -35,9 +38,16 @@ export function NewProjectModal({ open, onOpenChange }: NewProjectModalProps) {
 
   const handleSubmit = (data: ProjectCreate) => {
     createProject.mutate(data, {
-      onSuccess: () => {
+      onSuccess: async (result) => {
         showToast.success("프로젝트가 생성되었습니다.");
         handleClose();
+
+        const questions = await getQuestions(result.id);
+        if (questions.length > 0) {
+          router.push(`/chat/${result.id}/${questions[0].id}`);
+        } else {
+          throw new Error("생성된 문항을 찾을 수 없습니다.");
+        }
       },
       onError: () => {
         showToast.error("생성 중 오류가 발생했습니다.");

--- a/types/api.ts
+++ b/types/api.ts
@@ -167,7 +167,7 @@ export interface ProjectCreate {
   recruit_notice: string;
   company_talent?: string | null;
   due_date?: string | null;
-  questions?: QuestionCreate[];
+  questions: QuestionCreate[];
 }
 
 export interface ExperienceCreate {


### PR DESCRIPTION
## Summary


프로젝트 생성 시 폼 검증을 적용하고, 생성 완료 후 해당 프로젝트의 채팅 페이지로 자동 이동하도록 개선합니다.

## Tasks

- [x] 프로젝트 생성 성공 시 문항 조회 후 `/chat/{projectId}/{questionId}`로 라우팅
- [x] `createProject` 반환 타입을 `Project`로 명시
- [x] `ProjectCreate.questions`를 필수 필드로 변경
- [x] Step 1 "다음으로" 클릭 시 필수 필드(회사명, 직무, 채용 공고) 검증 적용
- [x] Step 2 최소 1개 문항 입력 필수 검증 및 에러 메시지 추가
- [x] 검증 우회되던 dead code 제거

## To Reviewer

- `ProjectRead` 응답에 `question_id`가 없어서, 생성 후 `getQuestions`로 문항 목록을 추가 조회하여 첫 번째 문항 ID로 라우팅합니다.
- 기존 "다음으로" 버튼은 `onClick`으로 직접 스텝 전환하여 zod 검증을 완전히 우회하고 있었습니다. `trigger`를 사용하여 스텝별 검증을 적용했습니다.

## Screenshot


https://github.com/user-attachments/assets/78b26987-b7b1-429f-868c-1bc43bd15633
