### PR TITLE
Feat(chat): DraftPanel 작성완료 토글 및 답변 수정 기능

### DIFF
--- a/app/(main)/chat/[projectId]/_components/Panel/CompleteToggleButton.tsx
+++ b/app/(main)/chat/[projectId]/_components/Panel/CompleteToggleButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+interface CompleteToggleButtonProps {
+  isCompleted: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path
+        d="M8 12L11 15L16 9"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function CompleteToggleButton({
+  isCompleted,
+  onClick,
+  disabled,
+}: CompleteToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex w-25 items-center justify-center gap-1.5 rounded-lg border pl-2 pr-2.5 py-1.25 text-body-7-1 transition-colors cursor-pointer ${
+        isCompleted
+          ? "bg-primary-20 border-primary-100 text-primary-100 hover:bg-primary-50"
+          : "border-gray-100 text-gray-200 hover:bg-gray-50"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+    >
+      <CheckIcon />
+      <span>작성완료</span>
+    </button>
+  );
+}

--- a/app/(main)/chat/[projectId]/_components/Panel/DraftPanel.tsx
+++ b/app/(main)/chat/[projectId]/_components/Panel/DraftPanel.tsx
@@ -1,19 +1,75 @@
 "use client";
 
+import { useState, useEffect, useRef } from "react";
+import { useParams } from "next/navigation";
 import { useChatStore } from "../../_store/useChatStore";
-import { Button } from "@/components/ui/button";
-import Image from "next/image";
+import { useProjectContext } from "../../_context";
+import { useToggleComplete, useSaveAnswer } from "../../_hooks";
+import { showToast } from "@/libs/toast";
+import { CompleteToggleButton } from "./CompleteToggleButton";
+
 interface DraftPanelProps {
   maxLength?: number;
 }
 
 export function DraftPanel({ maxLength }: DraftPanelProps) {
+  const { questionId } = useParams<{ projectId: string; questionId: string }>();
+  const { questions } = useProjectContext();
   const draftContent = useChatStore((s) => s.draftContent);
-  const charCount = draftContent?.length || 0;
+
+  const currentQuestion = questions.find((q) => q.id === questionId);
+  const [isCompleted, setIsCompleted] = useState(
+    currentQuestion?.is_completed ?? false,
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setIsCompleted(currentQuestion?.is_completed ?? false);
+  }, [currentQuestion?.is_completed]);
+
+  useEffect(() => {
+    setIsEditing(false);
+  }, [questionId]);
+
+  const toggleComplete = useToggleComplete();
+  const saveAnswer = useSaveAnswer({
+    onSuccess: () => {
+      useChatStore.getState().setDraftContent(editValue);
+      setIsEditing(false);
+    },
+  });
+
+  const displayContent = isEditing ? editValue : draftContent;
+  const charCount = displayContent?.length || 0;
+
+  const handleToggleComplete = () => {
+    const prev = isCompleted;
+    setIsCompleted(!prev);
+    toggleComplete.mutate(undefined, {
+      onSuccess: () => {
+        showToast.success(
+          !prev ? "작성완료 처리되었습니다." : "작성완료가 해제되었습니다.",
+        );
+      },
+      onError: () => setIsCompleted(prev),
+    });
+  };
+
+  const handleEdit = () => {
+    setEditValue(draftContent || "");
+    setIsEditing(true);
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  };
+
+  const handleSave = () => {
+    saveAnswer.mutate(editValue);
+  };
 
   return (
     <div className="flex-1 flex flex-col gap-8 px-7 pt-5 pb-8 overflow-hidden">
-      {/* 글자수 카운터 */}
+      {/* 글자수 카운터 + 완료 토글 */}
       <div className="flex items-center justify-between">
         <div className="shrink-0">
           <span className="text-body-5-5 text-gray-400 opacity-60">
@@ -21,14 +77,23 @@ export function DraftPanel({ maxLength }: DraftPanelProps) {
           </span>
         </div>
 
-        <Button variant="ghost" className="size-6 p-0">
-          <Image src="/icons/edit.svg" alt="trash" width={24} height={24} />
-        </Button>
+        <CompleteToggleButton
+          isCompleted={isCompleted}
+          onClick={handleToggleComplete}
+          disabled={toggleComplete.isPending}
+        />
       </div>
 
       {/* 내용 */}
       <div className="flex-1 overflow-y-auto">
-        {draftContent ? (
+        {isEditing ? (
+          <textarea
+            ref={textareaRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            className="w-full h-full text-body-6-1 text-gray-400 whitespace-pre-wrap resize-none outline-none bg-transparent"
+          />
+        ) : draftContent ? (
           <p className="text-body-6-1 text-gray-400 whitespace-pre-wrap">
             {draftContent}
           </p>
@@ -40,9 +105,30 @@ export function DraftPanel({ maxLength }: DraftPanelProps) {
           </p>
         )}
       </div>
-      <Button variant="primary" className="w-full">
-        작성 완료
-      </Button>
+
+      {/* 하단 버튼 */}
+      {draftContent && (
+        <>
+          {isEditing ? (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saveAnswer.isPending}
+              className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-100 text-white text-body-5-2 cursor-pointer transition-colors hover:bg-primary-200 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            >
+              {saveAnswer.isPending ? "저장 중..." : "저장하기"}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleEdit}
+              className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-60 text-primary-200 text-body-5-2 cursor-pointer transition-colors hover:bg-primary-70"
+            >
+              수정하기
+            </button>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/app/(main)/chat/[projectId]/_components/Panel/DraftPanel.tsx
+++ b/app/(main)/chat/[projectId]/_components/Panel/DraftPanel.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
 import { useParams } from "next/navigation";
-import { useChatStore } from "../../_store/useChatStore";
 import { useProjectContext } from "../../_context";
-import { useToggleComplete, useSaveAnswer } from "../../_hooks";
-import { showToast } from "@/libs/toast";
+import { useToggleComplete, useDraftEdit } from "../../_hooks";
 import { CompleteToggleButton } from "./CompleteToggleButton";
 
 interface DraftPanelProps {
@@ -15,72 +12,42 @@ interface DraftPanelProps {
 export function DraftPanel({ maxLength }: DraftPanelProps) {
   const { questionId } = useParams<{ projectId: string; questionId: string }>();
   const { questions } = useProjectContext();
-  const draftContent = useChatStore((s) => s.draftContent);
 
   const currentQuestion = questions.find((q) => q.id === questionId);
-  const [isCompleted, setIsCompleted] = useState(
-    currentQuestion?.is_completed ?? false,
-  );
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    setIsCompleted(currentQuestion?.is_completed ?? false);
-  }, [currentQuestion?.is_completed]);
-
-  useEffect(() => {
-    setIsEditing(false);
-  }, [questionId]);
-
-  const toggleComplete = useToggleComplete();
-  const saveAnswer = useSaveAnswer({
-    onSuccess: () => {
-      useChatStore.getState().setDraftContent(editValue);
-      setIsEditing(false);
-    },
+  const {
+    isCompleted,
+    toggle,
+    isPending: isTogglePending,
+  } = useToggleComplete({
+    initialCompleted: currentQuestion?.is_completed ?? false,
   });
 
-  const displayContent = isEditing ? editValue : draftContent;
+  const {
+    isEditing,
+    editValue,
+    setEditValue,
+    textareaRef,
+    startEdit,
+    save,
+    isSaving,
+    draftContent,
+    displayContent,
+  } = useDraftEdit();
+
   const charCount = displayContent?.length || 0;
-
-  const handleToggleComplete = () => {
-    const prev = isCompleted;
-    setIsCompleted(!prev);
-    toggleComplete.mutate(undefined, {
-      onSuccess: () => {
-        showToast.success(
-          !prev ? "작성완료 처리되었습니다." : "작성완료가 해제되었습니다.",
-        );
-      },
-      onError: () => setIsCompleted(prev),
-    });
-  };
-
-  const handleEdit = () => {
-    setEditValue(draftContent || "");
-    setIsEditing(true);
-    setTimeout(() => textareaRef.current?.focus(), 0);
-  };
-
-  const handleSave = () => {
-    saveAnswer.mutate(editValue);
-  };
 
   return (
     <div className="flex-1 flex flex-col gap-8 px-7 pt-5 pb-8 overflow-hidden">
       {/* 글자수 카운터 + 완료 토글 */}
       <div className="flex items-center justify-between">
-        <div className="shrink-0">
-          <span className="text-body-5-5 text-gray-400 opacity-60">
-            {charCount} / {maxLength || 1000}
-          </span>
-        </div>
+        <span className="text-body-5-5 text-gray-400 opacity-60">
+          {charCount} / {maxLength || 1000}
+        </span>
 
         <CompleteToggleButton
           isCompleted={isCompleted}
-          onClick={handleToggleComplete}
-          disabled={toggleComplete.isPending}
+          onClick={toggle}
+          disabled={isTogglePending}
         />
       </div>
 
@@ -107,28 +74,25 @@ export function DraftPanel({ maxLength }: DraftPanelProps) {
       </div>
 
       {/* 하단 버튼 */}
-      {draftContent && (
-        <>
-          {isEditing ? (
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saveAnswer.isPending}
-              className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-100 text-white text-body-5-2 cursor-pointer transition-colors hover:bg-primary-200 disabled:bg-gray-100 disabled:cursor-not-allowed"
-            >
-              {saveAnswer.isPending ? "저장 중..." : "저장하기"}
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={handleEdit}
-              className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-60 text-primary-200 text-body-5-2 cursor-pointer transition-colors hover:bg-primary-70"
-            >
-              수정하기
-            </button>
-          )}
-        </>
-      )}
+      {draftContent &&
+        (isEditing ? (
+          <button
+            type="button"
+            onClick={save}
+            disabled={isSaving}
+            className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-100 text-white text-body-5-2 cursor-pointer transition-colors hover:bg-primary-200 disabled:bg-gray-100 disabled:cursor-not-allowed"
+          >
+            {isSaving ? "저장 중..." : "저장하기"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={startEdit}
+            className="w-full h-11.25 flex items-center justify-center rounded-3.5 bg-primary-60 text-primary-200 text-body-5-2 cursor-pointer transition-colors hover:bg-primary-70"
+          >
+            수정하기
+          </button>
+        ))}
     </div>
   );
 }

--- a/app/(main)/chat/[projectId]/_hooks/index.ts
+++ b/app/(main)/chat/[projectId]/_hooks/index.ts
@@ -3,3 +3,5 @@ export { useChatStream } from './useChatStream';
 export { useSyncChatStore } from './useSyncChatStore';
 export { useInfiniteScrollUp } from './useInfiniteScrollUp';
 export { useChatHistoryPagination } from './useChatHistoryPagination';
+export { useToggleComplete } from './useToggleComplete';
+export { useSaveAnswer } from './useSaveAnswer';

--- a/app/(main)/chat/[projectId]/_hooks/index.ts
+++ b/app/(main)/chat/[projectId]/_hooks/index.ts
@@ -5,3 +5,4 @@ export { useInfiniteScrollUp } from './useInfiniteScrollUp';
 export { useChatHistoryPagination } from './useChatHistoryPagination';
 export { useToggleComplete } from './useToggleComplete';
 export { useSaveAnswer } from './useSaveAnswer';
+export { useDraftEdit } from './useDraftEdit';

--- a/app/(main)/chat/[projectId]/_hooks/useDraftEdit.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useDraftEdit.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect, useRef } from "react";
+import { useParams } from "next/navigation";
+import { useChatStore } from "../_store/useChatStore";
+import { useSaveAnswer } from "./useSaveAnswer";
+
+export function useDraftEdit() {
+  const { questionId } = useParams<{
+    projectId: string;
+    questionId: string;
+  }>();
+
+  const draftContent = useChatStore((s) => s.draftContent);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setIsEditing(false);
+  }, [questionId]);
+
+  useEffect(() => {
+    if (isEditing) {
+      textareaRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const saveAnswer = useSaveAnswer({
+    onSuccess: () => {
+      useChatStore.getState().setDraftContent(editValue);
+      setIsEditing(false);
+    },
+  });
+
+  const startEdit = () => {
+    setEditValue(draftContent || "");
+    setIsEditing(true);
+  };
+
+  const save = () => {
+    saveAnswer.mutate(editValue);
+  };
+
+  const displayContent = isEditing ? editValue : draftContent;
+
+  return {
+    isEditing,
+    editValue,
+    setEditValue,
+    textareaRef,
+    startEdit,
+    save,
+    isSaving: saveAnswer.isPending,
+    draftContent,
+    displayContent,
+  };
+}

--- a/app/(main)/chat/[projectId]/_hooks/useSaveAnswer.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useSaveAnswer.ts
@@ -1,0 +1,27 @@
+import { useMutation } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { updateQuestion } from "@/app/_actions/projects";
+import { showToast } from "@/libs/toast";
+
+interface UseSaveAnswerOptions {
+  onSuccess?: () => void;
+}
+
+export function useSaveAnswer({ onSuccess }: UseSaveAnswerOptions = {}) {
+  const { projectId, questionId } = useParams<{
+    projectId: string;
+    questionId: string;
+  }>();
+
+  return useMutation({
+    mutationFn: (answer: string) =>
+      updateQuestion(projectId, questionId, { answer }),
+    onSuccess: () => {
+      showToast.success("자기소개서가 저장되었습니다.");
+      onSuccess?.();
+    },
+    onError: () => {
+      showToast.error("자기소개서 저장에 실패했습니다.");
+    },
+  });
+}

--- a/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { toggleQuestionComplete } from "@/app/_actions/projects";
+import { showToast } from "@/libs/toast";
+
+export function useToggleComplete() {
+  const { projectId, questionId } = useParams<{
+    projectId: string;
+    questionId: string;
+  }>();
+
+  return useMutation({
+    mutationFn: () => toggleQuestionComplete(projectId, questionId),
+    onError: () => {
+      showToast.error("작성완료 상태 변경에 실패했습니다.");
+    },
+  });
+}

--- a/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
@@ -1,18 +1,47 @@
+import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { toggleQuestionComplete } from "@/app/_actions/projects";
 import { showToast } from "@/libs/toast";
 
-export function useToggleComplete() {
+interface UseToggleCompleteOptions {
+  initialCompleted: boolean;
+}
+
+export function useToggleComplete({
+  initialCompleted,
+}: UseToggleCompleteOptions) {
   const { projectId, questionId } = useParams<{
     projectId: string;
     questionId: string;
   }>();
 
-  return useMutation({
+  const [isCompleted, setIsCompleted] = useState(initialCompleted);
+
+  useEffect(() => {
+    setIsCompleted(initialCompleted);
+  }, [initialCompleted]);
+
+  const mutation = useMutation({
     mutationFn: () => toggleQuestionComplete(projectId, questionId),
-    onError: () => {
-      showToast.error("작성완료 상태 변경에 실패했습니다.");
-    },
   });
+
+  const toggle = () => {
+    setIsCompleted(!isCompleted);
+    mutation.mutate(undefined, {
+      onSuccess: () => {
+        showToast.success(
+          !isCompleted
+            ? "작성완료 처리되었습니다."
+            : "작성완료가 해제되었습니다.",
+        );
+      },
+      onError: () => {
+        setIsCompleted(isCompleted);
+        showToast.error("작성완료 상태 변경에 실패했습니다.");
+      },
+    });
+  };
+
+  return { isCompleted, toggle, isPending: mutation.isPending };
 }

--- a/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useToggleComplete.ts
@@ -27,7 +27,7 @@ export function useToggleComplete({
   });
 
   const toggle = () => {
-    setIsCompleted(!isCompleted);
+    setIsCompleted((prev) => !prev);
     mutation.mutate(undefined, {
       onSuccess: () => {
         showToast.success(

--- a/app/_actions/projects.ts
+++ b/app/_actions/projects.ts
@@ -83,6 +83,21 @@ export async function updateQuestion(
 }
 
 /**
+ * 문항 작성완료 토글
+ */
+export async function toggleQuestionComplete(
+  projectId: string,
+  questionId: string,
+): Promise<Question> {
+  const result = await apiFetch<Question>(
+    API_ENDPOINTS.questionComplete(projectId, questionId),
+    { method: "PATCH" },
+  );
+  revalidatePath(`/chat/${projectId}`);
+  return result;
+}
+
+/**
  * 문항 삭제
  */
 export async function deleteQuestion(

--- a/libs/api-client.ts
+++ b/libs/api-client.ts
@@ -153,6 +153,8 @@ export const API_ENDPOINTS = {
   questions: (projectId: string) => `/api/v1/projects/${projectId}/questions/`,
   question: (projectId: string, questionId: string) =>
     `/api/v1/projects/${projectId}/questions/${questionId}`,
+  questionComplete: (projectId: string, questionId: string) =>
+    `/api/v1/projects/${projectId}/questions/${questionId}/complete`,
 
   // Chats
   chats: "/api/v1/projects/chats",

--- a/types/api.ts
+++ b/types/api.ts
@@ -105,6 +105,7 @@ export interface Question {
   question: string;
   max_length: number | null;
   answer: string | null;
+  is_completed: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -114,6 +115,7 @@ export interface QuestionListItem {
   question: string;
   max_length: number | null;
   answer: string | null;
+  is_completed: boolean;
 }
 
 // ============================================================================
@@ -183,8 +185,9 @@ export interface ExperienceCreate {
 }
 
 export interface QuestionUpdate {
-  question: string;
+  question?: string;
   max_length?: number | null;
+  answer?: string;
 }
 
 export interface ExperienceUpdate {


### PR DESCRIPTION
## Summary

DraftPanel에 작성완료 토글 및 답변 수정/저장 기능을 구현하고, 상태 로직을 커스텀 훅으로 분리하여 컴포넌트를 단순화했습니다.

## Tasks

- [x] Question, QuestionListItem 타입에 `is_completed` 필드 추가
- [x] QuestionUpdate 타입 수정 (`question` 옵셔널, `answer` 필드 추가)
- [x] `questionComplete` API 엔드포인트 및 `toggleQuestionComplete` 서버 액션 추가
- [x] `CompleteToggleButton` 컴포넌트 구현
- [x] `useToggleComplete` 훅 구현 (낙관적 업데이트 + 함수형 업데이트 적용)
- [x] `useSaveAnswer` 훅 구현
- [x] `useDraftEdit` 훅 구현 (편집 모드 상태 캡슐화)
- [x] DraftPanel 리팩토링 (훅 조합 + 렌더링만 담당)

## To Reviewer

- `useToggleComplete`는 낙관적 업데이트 패턴을 사용합니다. 토글 시 즉시 UI를 반영하고, 실패 시 롤백합니다.
- `useDraftEdit`는 편집 모드 진입/저장/취소 로직을 캡슐화합니다. textarea focus는 `setTimeout` 대신 `useEffect`로 처리합니다.

## Screenshot


https://github.com/user-attachments/assets/1aa95fe5-642f-420c-9879-8a6cebb838c5

