### PR TITLE
Feat(experience): 경험 카드 UI/UX 개선 및 스크롤 이동 기능 추가

### DIFF
--- a/app/(main)/chat/[projectId]/_components/Experience/ExperienceCard.tsx
+++ b/app/(main)/chat/[projectId]/_components/Experience/ExperienceCard.tsx
@@ -6,27 +6,6 @@ import { CategoryTag } from "./CategoryTag";
 import { HashtagBadge } from "./HashtagBadge";
 import { ExperienceOptionsMenu } from "./ExperienceOptionsMenu";
 
-function CheckIcon({ selected }: { selected: boolean }) {
-  return (
-    <svg
-      width="27"
-      height="27"
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle cx="12" cy="12" r="10" fill={selected ? "#0066FF" : "#E1E4ED"} />
-      <path
-        d="M8 12L11 15L16 9"
-        stroke="white"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 interface ExperienceCardProps {
   experience: Experience;
   similarityScore: number;
@@ -53,21 +32,14 @@ export function ExperienceCard({
   const isDisabled = disabled && !isSelected;
 
   const cardStyles = [
-    "relative w-full px-5 py-4 rounded-3.5 text-left transition-all border-2",
+    "relative w-full px-4.5 py-3.5 rounded-3.5 text-left transition-all",
     isSelected
-      ? "bg-primary-10 border-primary-100"
-      : "bg-white border-transparent hover:border-gray-80",
+      ? "bg-primary-10 border-2 border-primary-100"
+      : "bg-white border-2 border-gray-70",
     isDisabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
   ].join(" ");
 
   const handleCardClick = () => {
-    if (!isDisabled) {
-      onShowDetail(experience);
-    }
-  };
-
-  const handleToggleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
     if (!isDisabled) {
       onToggle();
     }
@@ -75,39 +47,27 @@ export function ExperienceCard({
 
   return (
     <div className={cardStyles} onClick={handleCardClick}>
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <span className="text-body-8-1 text-primary-200 shrink-0">
-              {scorePercent}점
-            </span>
-            <h4 className="text-body-4 text-primary-500 truncate">
-              {experience.title}
-            </h4>
-          </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-body-8-1 text-primary-200">
+            공고 매칭 점수: {scorePercent}점
+          </span>
           <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
             <ExperienceOptionsMenu
+              onShowDetail={() => onShowDetail(experience)}
               onEdit={() => onEdit(experience)}
               onDelete={() => onDelete(experience)}
             />
           </div>
         </div>
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-1.5 flex-wrap flex-1">
-            <CategoryTag category={experience.category} />
-            {tags.slice(0, 2).map((tag) => (
-              <HashtagBadge key={tag} tag={tag} highlighted={isSelected} />
-            ))}
-          </div>
-          <button
-            type="button"
-            onClick={handleToggleClick}
-            disabled={isDisabled}
-            className="shrink-0 p-0.5 cursor-pointer disabled:cursor-not-allowed"
-            aria-label={isSelected ? "선택됨" : "선택하기"}
-          >
-            <CheckIcon selected={isSelected} />
-          </button>
+        <h4 className="text-body-4 text-primary-500 truncate">
+          {experience.title}
+        </h4>
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <CategoryTag category={experience.category} />
+          {tags.slice(0, 2).map((tag) => (
+            <HashtagBadge key={tag} tag={tag} highlighted={isSelected} />
+          ))}
         </div>
       </div>
     </div>

--- a/app/(main)/chat/[projectId]/_components/Experience/ExperienceCards.tsx
+++ b/app/(main)/chat/[projectId]/_components/Experience/ExperienceCards.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ExperienceCard } from "./ExperienceCard";
 import { ExperienceDetailModal } from "./ExperienceDetailModal";
@@ -21,6 +21,8 @@ export function ExperienceCards({ matchedExperiences }: ExperienceCardsProps) {
   const selectedIds = useChatStore((s) => s.selectedExperienceIds);
   const toggleExperience = useChatStore((s) => s.toggleExperience);
   const removeExperience = useChatStore((s) => s.removeExperience);
+  const scrollTargetExperienceId = useChatStore((s) => s.scrollTargetExperienceId);
+  const setScrollTargetExperienceId = useChatStore((s) => s.setScrollTargetExperienceId);
 
   const deleteExperience = useDeleteExperience();
 
@@ -37,6 +39,19 @@ export function ExperienceCards({ matchedExperiences }: ExperienceCardsProps) {
   const matchedIds = new Set(matchedExperiences.map((me) => me.experience.id));
   const validSelectedCount = selectedIds.filter((id) => matchedIds.has(id)).length;
   const canSelectMore = validSelectedCount < MAX_EXPERIENCE_SELECTION;
+
+  // 새 경험 생성 후 스크롤
+  useEffect(() => {
+    if (!scrollTargetExperienceId) return;
+
+    const el = document.querySelector(
+      `[data-experience-id="${scrollTargetExperienceId}"]`
+    );
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      setScrollTargetExperienceId(null);
+    }
+  }, [scrollTargetExperienceId, matchedExperiences, setScrollTargetExperienceId]);
 
   const handleShowDetail = (experience: Experience) => {
     setDetailExperience(experience);
@@ -80,17 +95,18 @@ export function ExperienceCards({ matchedExperiences }: ExperienceCardsProps) {
     <>
       <div className="flex flex-col gap-3 py-2">
         {matchedExperiences.map(({ experience, similarity_score }) => (
-          <ExperienceCard
-            key={experience.id}
-            experience={experience}
-            similarityScore={similarity_score}
-            isSelected={selectedIds.includes(experience.id)}
-            onToggle={() => toggleExperience(experience.id)}
-            onShowDetail={handleShowDetail}
-            onEdit={handleEdit}
-            onDelete={handleDeleteRequest}
-            disabled={!canSelectMore}
-          />
+          <div key={experience.id} data-experience-id={experience.id}>
+            <ExperienceCard
+              experience={experience}
+              similarityScore={similarity_score}
+              isSelected={selectedIds.includes(experience.id)}
+              onToggle={() => toggleExperience(experience.id)}
+              onShowDetail={handleShowDetail}
+              onEdit={handleEdit}
+              onDelete={handleDeleteRequest}
+              disabled={!canSelectMore}
+            />
+          </div>
         ))}
       </div>
 

--- a/app/(main)/chat/[projectId]/_components/Experience/ExperienceListShell.tsx
+++ b/app/(main)/chat/[projectId]/_components/Experience/ExperienceListShell.tsx
@@ -12,7 +12,7 @@ export function ExperienceListShell({ children, onAddClick }: ExperienceListShel
   return (
     <div className="flex-1 flex flex-col gap-5 pt-5 pb-8 overflow-hidden">
       <p className="text-body-5-5 text-gray-400 opacity-60 px-7">
-        반영할 경험카드를 선택하세요 (최대 3개)
+        사용할 경험을 선택하세요 (최대 3개)
       </p>
 
       <div className="flex-1 flex flex-col gap-7 overflow-y-auto px-7">

--- a/app/(main)/chat/[projectId]/_components/Experience/ExperienceOptionsMenu.tsx
+++ b/app/(main)/chat/[projectId]/_components/Experience/ExperienceOptionsMenu.tsx
@@ -9,11 +9,13 @@ import {
 import Image from "next/image";
 
 interface ExperienceOptionsMenuProps {
+  onShowDetail: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }
 
 export function ExperienceOptionsMenu({
+  onShowDetail,
   onEdit,
   onDelete,
 }: ExperienceOptionsMenuProps) {
@@ -40,22 +42,32 @@ export function ExperienceOptionsMenu({
         <DropdownMenuItem
           onClick={(e) => {
             e.stopPropagation();
+            onShowDetail();
+          }}
+          className="px-4 py-3.5 gap-3 cursor-pointer hover:bg-gray-50 focus:bg-gray-50 border-b border-gray-70"
+        >
+          <Image src="/icons/icon-expand.svg" alt="" width={18} height={18} />
+          <span className="text-body-5-3 text-[#17181E]">전체보기</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.stopPropagation();
             onEdit();
           }}
-          className="px-5 py-3.75 gap-3 cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
+          className="px-4 py-3.5 gap-3 cursor-pointer hover:bg-gray-50 focus:bg-gray-50 border-b border-gray-70"
         >
           <Image src="/icons/icon-edit.svg" alt="" width={18} height={18} />
-          <span className="text-body-5-3 text-primary-600">수정</span>
+          <span className="text-body-5-3 text-[#17181E]">수정하기</span>
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={(e) => {
             e.stopPropagation();
             onDelete();
           }}
-          className="px-5 py-3.75 gap-3 cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
+          className="px-4 py-3.5 gap-3 cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
         >
           <Image src="/icons/icon-trash.svg" alt="" width={18} height={18} />
-          <span className="text-body-5-3 text-primary-600">삭제</span>
+          <span className="text-body-5-3 text-[#17181E]">삭제하기</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/app/(main)/chat/[projectId]/_components/Panel/ChatPanel.tsx
+++ b/app/(main)/chat/[projectId]/_components/Panel/ChatPanel.tsx
@@ -17,12 +17,16 @@ export function ChatPanel({ maxLength, experienceCards }: ChatPanelProps) {
   const router = useRouter();
   const activeTab = useChatStore((s) => s.activePanelTab);
   const storeMaxLength = useChatStore((s) => s.maxLength);
+  const setScrollTargetExperienceId = useChatStore((s) => s.setScrollTargetExperienceId);
   const [isExperienceModalOpen, setIsExperienceModalOpen] = useState(false);
 
   const effectiveMaxLength = maxLength ?? storeMaxLength;
 
-  const handleExperienceCreated = () => {
+  const handleExperienceCreated = (createdId?: string) => {
     router.refresh();
+    if (createdId) {
+      setScrollTargetExperienceId(createdId);
+    }
   };
 
   return (

--- a/app/(main)/chat/[projectId]/_hooks/useChatStream.ts
+++ b/app/(main)/chat/[projectId]/_hooks/useChatStream.ts
@@ -3,6 +3,7 @@
 import { useRef } from 'react';
 import { useChat, UIMessage } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
+import { refreshAuthTokens } from '@/libs/auth';
 import type { ChatMessageMetadata } from '@/types/chat';
 
 interface UseChatStreamOptions {
@@ -25,6 +26,16 @@ export function useChatStream({
     messages: initialMessages,
     transport: new DefaultChatTransport({
       api: '/api/chat',
+      fetch: async (input, init) => {
+        const response = await fetch(input, init);
+        if (response.status === 401) {
+          const refreshed = await refreshAuthTokens();
+          if (refreshed) {
+            return fetch(input, init);
+          }
+        }
+        return response;
+      },
     }),
     onFinish: ({ message }) => onFinish?.(message),
   });

--- a/app/(main)/chat/[projectId]/_store/useChatStore.ts
+++ b/app/(main)/chat/[projectId]/_store/useChatStore.ts
@@ -32,6 +32,10 @@ interface ChatStore {
   // 문항 최대 글자수
   maxLength: number;
   setMaxLength: (length: number) => void;
+
+  // 스크롤 타겟 경험 ID
+  scrollTargetExperienceId: string | null;
+  setScrollTargetExperienceId: (id: string | null) => void;
 }
 
 export const useChatStore = create<ChatStore>((set, get) => ({
@@ -98,4 +102,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   // 문항 최대 글자수
   maxLength: 1000,
   setMaxLength: (length) => set({ maxLength: length }),
+
+  // 스크롤 타겟 경험 ID
+  scrollTargetExperienceId: null,
+  setScrollTargetExperienceId: (id) => set({ scrollTargetExperienceId: id }),
 }));

--- a/app/_actions/experiences.ts
+++ b/app/_actions/experiences.ts
@@ -21,8 +21,8 @@ export async function getExperiences(): Promise<Experience[]> {
 /**
  * 경험 생성
  */
-export async function createExperience(data: ExperienceCreate) {
-  return apiFetch(API_ENDPOINTS.experiences, {
+export async function createExperience(data: ExperienceCreate): Promise<Experience> {
+  return apiFetch<Experience>(API_ENDPOINTS.experiences, {
     method: "POST",
     body: JSON.stringify(data),
   });

--- a/app/_components/NewExperienceForm.tsx
+++ b/app/_components/NewExperienceForm.tsx
@@ -67,7 +67,7 @@ const experienceFormSchema = z
         );
       }
       if (data.experience_format === EXPERIENCE_FORMAT.FREE) {
-        return data.content.trim().length >= minLen;
+        return data.content.trim().length >= 1;
       }
       return true;
     },

--- a/app/_components/NewExperienceModal.tsx
+++ b/app/_components/NewExperienceModal.tsx
@@ -40,7 +40,7 @@ const STEP_TITLES = {
 interface NewExperienceModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSuccess?: () => void;
+  onSuccess?: (createdId?: string) => void;
 }
 
 export function NewExperienceModal({
@@ -60,10 +60,10 @@ export function NewExperienceModal({
 
   const handleSubmit = (data: ExperienceCreate) => {
     createExperience.mutate(data, {
-      onSuccess: () => {
+      onSuccess: (response) => {
         showToast.success("경험이 등록되었습니다.");
         handleClose();
-        onSuccess?.();
+        onSuccess?.(response?.id);
       },
       onError: () => {
         showToast.error("등록 중 오류가 발생했습니다.");

--- a/libs/auth.ts
+++ b/libs/auth.ts
@@ -62,7 +62,7 @@ export async function refreshAuthTokens(): Promise<boolean> {
       const res = await fetch(REFRESH_API_URL, {
         method: "POST",
         credentials: "include",
-        headers: { "Content-Type": "application/json", credentials: "include" },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
       if (!res.ok) return false;

--- a/public/icons/icon-expand.svg
+++ b/public/icons/icon-expand.svg
@@ -1,0 +1,6 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.5 2.25H15.75V7.5" stroke="#17181E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7.5 15.75H2.25V10.5" stroke="#17181E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M15.75 2.25L10.5 7.5" stroke="#17181E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.25 15.75L7.5 10.5" stroke="#17181E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

경험 카드의 UX를 개선하여 카드 클릭 시 선택 토글로 변경하고, Figma 디자인에 맞춰 레이아웃을 재구성합니다. 경험 추가 후 새 경험 카드로 자동 스크롤되도록 개선하고, 자유형식 50자 최소조건을 제거합니다.

## Tasks

- [x] 카드 클릭 동작을 상세보기 → 선택 토글로 변경, 하단 체크 아이콘 제거
- [x] 케밥 메뉴에 "전체보기" 항목 추가 및 메뉴 스타일 Figma 반영
- [x] 카드 레이아웃 세로배치(점수→제목→태그), "공고 매칭 점수: N점" 표시
- [x] 선택/비선택 border를 `border-2`로 통일하여 레이아웃 시프트 방지
- [x] 경험 추가 후 새 경험 카드로 smooth 스크롤 이동
- [x] 자유형식(FREE) 50자 최소조건 제거 (빈 값만 방지)
- [x] 안내 문구 변경: "사용할 경험을 선택하세요 (최대 3개)"
- [x] 채팅 스트림 401 토큰 갱신 및 중복 credentials 헤더 제거

## To Reviewer

- 카드 클릭=선택, 상세보기는 케밥 메뉴 "전체보기"로 이동했습니다
- border 통일(`border-2`)로 선택 시 카드 높이 변동(자글자글) 이슈 해결했습니다

## Screenshot


https://github.com/user-attachments/assets/95089d67-ee95-4df3-a35a-38b96557f63b

